### PR TITLE
CI Pipeline Updates

### DIFF
--- a/.github/workflows/tenant-deploy-prod.yml
+++ b/.github/workflows/tenant-deploy-prod.yml
@@ -65,7 +65,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-init.sh
+        bash terraform-init.sh
 
     - name: Terraform Plan Before
       env:
@@ -100,7 +100,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-plan-before.sh testplan
+        bash terraform-plan-before.sh testplan
 
     - name: Terraform Apply
       env:
@@ -135,7 +135,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-apply.sh testplan
+        bash terraform-apply.sh testplan
 
     - name: Terraform Plan After
       env:
@@ -170,4 +170,4 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-plan-after.sh testplan
+        bash terraform-plan-after.sh testplan

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -67,110 +67,110 @@ jobs:
         cd tenant
         bash terraform-init.sh
 
-    - name: Terraform Plan Before
-      env:
-        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+    # - name: Terraform Plan Before
+    #   env:
+    #     BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+    #     BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+    #     BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
 
-        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+    #     BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+    #     BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+    #     BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+    #     BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+    #     TF_VAR_parent_id: ${{ secrets.TENANTID }}
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+    #     TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+    #     TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+    #     TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+    #     TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+    #     TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
         
-        TF_VAR_running_ci_pipeline: "false"
+    #     TF_VAR_running_ci_pipeline: "false"
 
-        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+    #     ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+    #     ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+    #     ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+    #     ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
 
-        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-        TF_VAR_management_resources_location: "uksouth"
-        TF_VAR_connectivity_resources_location: "uksouth"
+    #     TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+    #     TF_VAR_management_resources_location: "uksouth"
+    #     TF_VAR_connectivity_resources_location: "uksouth"
 
-        TF_IN_AUTOMATION: "true"
-      run: |
-        cd tenant
-        bash terraform-plan-before.sh testplan
+    #     TF_IN_AUTOMATION: "true"
+    #   run: |
+    #     cd tenant
+    #     bash terraform-plan-before.sh testplan
 
-    - name: Terraform Apply
-      env:
-        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+    # - name: Terraform Apply
+    #   env:
+    #     BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+    #     BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+    #     BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
 
-        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+    #     BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+    #     BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+    #     BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+    #     BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+    #     TF_VAR_parent_id: ${{ secrets.TENANTID }}
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+    #     TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+    #     TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+    #     TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+    #     TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+    #     TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
         
-        TF_VAR_running_ci_pipeline: "false"
+    #     TF_VAR_running_ci_pipeline: "false"
 
-        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+    #     ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+    #     ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+    #     ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+    #     ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
 
-        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-        TF_VAR_management_resources_location: "uksouth"
-        TF_VAR_connectivity_resources_location: "uksouth"
+    #     TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+    #     TF_VAR_management_resources_location: "uksouth"
+    #     TF_VAR_connectivity_resources_location: "uksouth"
 
-        TF_IN_AUTOMATION: "true"
-      run: |
-        cd tenant
-        bash terraform-apply.sh testplan
+    #     TF_IN_AUTOMATION: "true"
+    #   run: |
+    #     cd tenant
+    #     bash terraform-apply.sh testplan
 
-    - name: Terraform Plan After
-      env:
-        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+    # - name: Terraform Plan After
+    #   env:
+    #     BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+    #     BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+    #     BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
 
-        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+    #     BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+    #     BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+    #     BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+    #     BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+    #     TF_VAR_parent_id: ${{ secrets.TENANTID }}
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+    #     TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+    #     TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+    #     TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+    #     TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+    #     TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
         
-        TF_VAR_running_ci_pipeline: "false"
+    #     TF_VAR_running_ci_pipeline: "false"
 
-        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+    #     ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+    #     ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+    #     ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+    #     ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
 
-        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-        TF_VAR_management_resources_location: "uksouth"
-        TF_VAR_connectivity_resources_location: "uksouth"
+    #     TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+    #     TF_VAR_management_resources_location: "uksouth"
+    #     TF_VAR_connectivity_resources_location: "uksouth"
 
-        TF_IN_AUTOMATION: "true"
-      run: |
-        cd tenant
-        bash terraform-plan-after.sh testplan
+    #     TF_IN_AUTOMATION: "true"
+    #   run: |
+    #     cd tenant
+    #     bash terraform-plan-after.sh testplan
 
     - name: Terraform Destroy
       env:

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     container:
-      image: ffmgmtacr.azurecr.io/build-agent-tools:latest
+      image: ffmgmtacr.azurecr.io/build-agent-tools:20210817.1 #latest
       credentials:
         username: ${{ secrets.CLIENTID }}
         password: ${{ secrets.CLIENTSECRET }}

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     container:
-      image: ffmgmtacr.azurecr.io/build-agent-tools:20210816.2 #latest
+      image: forefrontworkloads.azurecr.io/build-agent-tools:latest
       credentials:
         username: ${{ secrets.CLIENTID }}
         password: ${{ secrets.CLIENTSECRET }}

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -101,6 +101,8 @@ jobs:
       run: |
         cd tenant
         bash terraform-plan-before.sh testplan
+        bash terraform apply -refresh-only
+        bash terraform destroy
 
     - name: Terraform Apply
       env:

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -65,7 +65,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-init.sh
+        bash terraform-init.sh
 
     - name: Terraform Plan Before
       env:
@@ -100,7 +100,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-plan-before.sh testplan
+        bash terraform-plan-before.sh testplan
 
     - name: Terraform Apply
       env:
@@ -135,7 +135,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-apply.sh testplan
+        bash terraform-apply.sh testplan
 
     - name: Terraform Plan After
       env:
@@ -170,7 +170,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-plan-after.sh testplan
+        bash terraform-plan-after.sh testplan
 
     - name: Terraform Destroy
       env:
@@ -205,4 +205,4 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform-destroy.sh
+        bash terraform-destroy.sh

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     container:
-      image: forefrontworkloads.azurecr.io/build-agent-tools:latest
+      image: ffmgmtacr.azurecr.io/build-agent-tools:latest
       credentials:
         username: ${{ secrets.CLIENTID }}
         password: ${{ secrets.CLIENTSECRET }}

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -15,17 +15,6 @@ jobs:
         username: ${{ secrets.CLIENTID }}
         password: ${{ secrets.CLIENTSECRET }}
     steps:
-      
-    - uses: actions/checkout@v2
-    - run: whoami
-    - uses: Azure/login@v1
-      with:
-        creds: '{ "clientId": "${{ secrets.CLIENTID }}", "clientSecret": "${{ secrets.CLIENTSECRET }}", "subscriptionId": "${{ secrets.SUBID }}", "tenantId": "${{ secrets.TENANTID }}" }'
-    - uses: Azure/get-keyvault-secrets@v1
-      with:
-        keyvault: 'Forefront-azopsmcpv532jw'
-        secrets: 'backend-resgrp,backend-storage-account,backend-container,tf-var-root-name,tf-var-root-id,tf-var-connectivity-subid,tf-var-management-subid,tf-var-identity-subid,arm-client-id,arm-client-secret,arm-subscription-id,arm-tenant-id,tf-var-security-alerts-email-address'
-      id: getSecrets
     
     - name: Print tooling versions
       run: |
@@ -66,41 +55,6 @@ jobs:
       run: |
         cd tenant
         bash terraform-init.sh
-
-    - name: Terraform Plan Before
-      env:
-        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
-
-        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
-
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
-
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
-        
-        TF_VAR_running_ci_pipeline: "false"
-
-        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
-
-        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-        TF_VAR_management_resources_location: "uksouth"
-        TF_VAR_connectivity_resources_location: "uksouth"
-
-        TF_IN_AUTOMATION: "true"
-      run: |
-        cd tenant
-        bash terraform-plan-before.sh testplan
 
     - name: Terraform Refresh
       env:
@@ -170,7 +124,42 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        terraform destroy
+        terraform destroy -auto-approve
+
+    - name: Terraform Plan Before
+      env:
+        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+
+        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+
+        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+
+        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+        
+        TF_VAR_running_ci_pipeline: "false"
+
+        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+
+        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+        TF_VAR_management_resources_location: "uksouth"
+        TF_VAR_connectivity_resources_location: "uksouth"
+
+        TF_IN_AUTOMATION: "true"
+      run: |
+        cd tenant
+        bash terraform-plan-before.sh testplan
 
     - name: Terraform Apply
       env:

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -135,7 +135,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        bash terraform apply -refresh-only
+        terraform apply -refresh-only
 
     - name: Terraform Destroy
       env:
@@ -170,7 +170,7 @@ jobs:
         TF_IN_AUTOMATION: "true"
       run: |
         cd tenant
-        bash terraform destroy
+        terraform destroy
 
     - name: Terraform Apply
       env:

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -101,7 +101,75 @@ jobs:
       run: |
         cd tenant
         bash terraform-plan-before.sh testplan
+
+    - name: Terraform Refresh
+      env:
+        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+
+        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+
+        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+
+        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+        
+        TF_VAR_running_ci_pipeline: "false"
+
+        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+
+        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+        TF_VAR_management_resources_location: "uksouth"
+        TF_VAR_connectivity_resources_location: "uksouth"
+
+        TF_IN_AUTOMATION: "true"
+      run: |
+        cd tenant
         bash terraform apply -refresh-only
+
+    - name: Terraform Destroy
+      env:
+        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+
+        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+
+        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+
+        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+        
+        TF_VAR_running_ci_pipeline: "false"
+
+        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+
+        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+        TF_VAR_management_resources_location: "uksouth"
+        TF_VAR_connectivity_resources_location: "uksouth"
+
+        TF_IN_AUTOMATION: "true"
+      run: |
+        cd tenant
         bash terraform destroy
 
     - name: Terraform Apply

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -67,110 +67,110 @@ jobs:
         cd tenant
         bash terraform-init.sh
 
-    # - name: Terraform Plan Before
-    #   env:
-    #     BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-    #     BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-    #     BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+    - name: Terraform Plan Before
+      env:
+        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
 
-    #     BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-    #     BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-    #     BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-    #     BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-    #     TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: ${{ secrets.TENANTID }}
 
-    #     TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-    #     TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-    #     TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-    #     TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-    #     TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
         
-    #     TF_VAR_running_ci_pipeline: "false"
+        TF_VAR_running_ci_pipeline: "false"
 
-    #     ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-    #     ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-    #     ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-    #     ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
 
-    #     TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-    #     TF_VAR_management_resources_location: "uksouth"
-    #     TF_VAR_connectivity_resources_location: "uksouth"
+        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+        TF_VAR_management_resources_location: "uksouth"
+        TF_VAR_connectivity_resources_location: "uksouth"
 
-    #     TF_IN_AUTOMATION: "true"
-    #   run: |
-    #     cd tenant
-    #     bash terraform-plan-before.sh testplan
+        TF_IN_AUTOMATION: "true"
+      run: |
+        cd tenant
+        bash terraform-plan-before.sh testplan
 
-    # - name: Terraform Apply
-    #   env:
-    #     BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-    #     BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-    #     BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+    - name: Terraform Apply
+      env:
+        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
 
-    #     BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-    #     BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-    #     BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-    #     BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-    #     TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: ${{ secrets.TENANTID }}
 
-    #     TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-    #     TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-    #     TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-    #     TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-    #     TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
         
-    #     TF_VAR_running_ci_pipeline: "false"
+        TF_VAR_running_ci_pipeline: "false"
 
-    #     ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-    #     ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-    #     ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-    #     ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
 
-    #     TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-    #     TF_VAR_management_resources_location: "uksouth"
-    #     TF_VAR_connectivity_resources_location: "uksouth"
+        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+        TF_VAR_management_resources_location: "uksouth"
+        TF_VAR_connectivity_resources_location: "uksouth"
 
-    #     TF_IN_AUTOMATION: "true"
-    #   run: |
-    #     cd tenant
-    #     bash terraform-apply.sh testplan
+        TF_IN_AUTOMATION: "true"
+      run: |
+        cd tenant
+        bash terraform-apply.sh testplan
 
-    # - name: Terraform Plan After
-    #   env:
-    #     BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-    #     BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-    #     BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
+    - name: Terraform Plan After
+      env:
+        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
+        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
+        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
 
-    #     BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-    #     BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-    #     BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-    #     BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
+        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
+        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
+        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
+        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-    #     TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: ${{ secrets.TENANTID }}
 
-    #     TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-    #     TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-    #     TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-    #     TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-    #     TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
+        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
+        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
+        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
+        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
         
-    #     TF_VAR_running_ci_pipeline: "false"
+        TF_VAR_running_ci_pipeline: "false"
 
-    #     ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-    #     ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-    #     ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-    #     ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
+        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
+        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
+        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
+        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
 
-    #     TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-    #     TF_VAR_management_resources_location: "uksouth"
-    #     TF_VAR_connectivity_resources_location: "uksouth"
+        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
+        TF_VAR_management_resources_location: "uksouth"
+        TF_VAR_connectivity_resources_location: "uksouth"
 
-    #     TF_IN_AUTOMATION: "true"
-    #   run: |
-    #     cd tenant
-    #     bash terraform-plan-after.sh testplan
+        TF_IN_AUTOMATION: "true"
+      run: |
+        cd tenant
+        bash terraform-plan-after.sh testplan
 
     - name: Terraform Destroy
       env:

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -15,6 +15,16 @@ jobs:
         username: ${{ secrets.CLIENTID }}
         password: ${{ secrets.CLIENTSECRET }}
     steps:
+      
+    - uses: actions/checkout@v2
+    - uses: Azure/login@v1
+      with:
+        creds: '{ "clientId": "${{ secrets.CLIENTID }}", "clientSecret": "${{ secrets.CLIENTSECRET }}", "subscriptionId": "${{ secrets.SUBID }}", "tenantId": "${{ secrets.TENANTID }}" }'
+    - uses: Azure/get-keyvault-secrets@v1
+      with:
+        keyvault: 'Forefront-azopsmcpv532jw'
+        secrets: 'backend-resgrp,backend-storage-account,backend-container,tf-var-root-name,tf-var-root-id,tf-var-connectivity-subid,tf-var-management-subid,tf-var-identity-subid,arm-client-id,arm-client-secret,arm-subscription-id,arm-tenant-id,tf-var-security-alerts-email-address'
+      id: getSecrets
     
     - name: Print tooling versions
       run: |

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       
     - uses: actions/checkout@v2
-
+    - run: whoami
     - uses: Azure/login@v1
       with:
         creds: '{ "clientId": "${{ secrets.CLIENTID }}", "clientSecret": "${{ secrets.CLIENTSECRET }}", "subscriptionId": "${{ secrets.SUBID }}", "tenantId": "${{ secrets.TENANTID }}" }'

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: Azure/get-keyvault-secrets@v1
       with:
         keyvault: 'Forefront-azopsmcpv532jw'
-        secrets: 'backend-resgrp,backend-storage-account,backend-container,tf-var-root-name,tf-var-root-id,tf-var-connectivity-subid,tf-var-management-subid,tf-var-identity-subid,arm-client-id,arm-client-secret,arm-subscription-id,arm-tenant-id,tf-var-security-alerts-email-address'
+        secrets: 'backend-resgrp,backend-storage-account,backend-container,tf-var-connectivity-subid,tf-var-management-subid,tf-var-identity-subid,arm-client-id,arm-client-secret,arm-subscription-id,arm-tenant-id,tf-var-security-alerts-email-address'
       id: getSecrets
     
     - name: Print tooling versions
@@ -42,10 +42,10 @@ jobs:
         BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
         BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: "envsmgmt"
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_root_name: "Forefront-Test"
+        TF_VAR_root_id: "forefrtest"
         TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
         TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
         TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
@@ -66,76 +66,6 @@ jobs:
         cd tenant
         bash terraform-init.sh
 
-    - name: Terraform Refresh
-      env:
-        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
-
-        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
-
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
-
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
-        
-        TF_VAR_running_ci_pipeline: "false"
-
-        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
-
-        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-        TF_VAR_management_resources_location: "uksouth"
-        TF_VAR_connectivity_resources_location: "uksouth"
-
-        TF_IN_AUTOMATION: "true"
-      run: |
-        cd tenant
-        terraform apply -refresh-only
-
-    - name: Terraform Destroy
-      env:
-        BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
-        BACKEND_STORAGE_ACCOUNT: ${{ steps.getSecrets.outputs.backend-storage-account }}
-        BACKEND_CONTAINER: ${{ steps.getSecrets.outputs.backend-container }}
-
-        BACKEND_CLIENT_ID: ${{ secrets.CLIENTID }}
-        BACKEND_CLIENT_SECRET: ${{ secrets.CLIENTSECRET }}
-        BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
-        BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
-
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
-
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
-        TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
-        TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
-        TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
-        
-        TF_VAR_running_ci_pipeline: "false"
-
-        ARM_CLIENT_ID: ${{ steps.getSecrets.outputs.arm-client-id }}
-        ARM_CLIENT_SECRET: ${{ steps.getSecrets.outputs.arm-client-secret }}
-        ARM_SUBSCRIPTION_ID: ${{ steps.getSecrets.outputs.arm-subscription-id }}
-        ARM_TENANT_ID: ${{ steps.getSecrets.outputs.arm-tenant-id }}
-
-        TF_VAR_security_alerts_email_address: ${{ steps.getSecrets.outputs.tf-var-security-alerts-email-address }}
-        TF_VAR_management_resources_location: "uksouth"
-        TF_VAR_connectivity_resources_location: "uksouth"
-
-        TF_IN_AUTOMATION: "true"
-      run: |
-        cd tenant
-        terraform destroy -auto-approve
-
     - name: Terraform Plan Before
       env:
         BACKEND_RESGRP: ${{ steps.getSecrets.outputs.backend-resgrp }}
@@ -147,10 +77,10 @@ jobs:
         BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
         BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: "envsmgmt"
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_root_name: "Forefront-Test"
+        TF_VAR_root_id: "forefrtest"
         TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
         TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
         TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
@@ -182,10 +112,10 @@ jobs:
         BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
         BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: "envsmgmt"
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_root_name: "Forefront-Test"
+        TF_VAR_root_id: "forefrtest"
         TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
         TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
         TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
@@ -217,10 +147,10 @@ jobs:
         BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
         BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: "envsmgmt"
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_root_name: "Forefront-Test"
+        TF_VAR_root_id: "forefrtest"
         TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
         TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
         TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}
@@ -252,10 +182,10 @@ jobs:
         BACKEND_CLIENT_SUBSCRIPTION_ID: ${{ secrets.SUBID }}
         BACKEND_CLIENT_TENANTID: ${{ secrets.TENANTID }}
 
-        TF_VAR_parent_id: ${{ secrets.TENANTID }}
+        TF_VAR_parent_id: "envsmgmt"
 
-        TF_VAR_root_name: ${{ steps.getSecrets.outputs.tf-var-root-name }}
-        TF_VAR_root_id: ${{ steps.getSecrets.outputs.tf-var-root-id }}
+        TF_VAR_root_name: "Forefront-Test"
+        TF_VAR_root_id: "forefrtest"
         TF_VAR_connectivity_subid: ${{ steps.getSecrets.outputs.tf-var-connectivity-subid }}
         TF_VAR_management_subid: ${{ steps.getSecrets.outputs.tf-var-management-subid }}
         TF_VAR_identity_subid: ${{ steps.getSecrets.outputs.tf-var-identity-subid  }}

--- a/.github/workflows/tenant-deploy-test.yml
+++ b/.github/workflows/tenant-deploy-test.yml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     container:
-      image: ffmgmtacr.azurecr.io/build-agent-tools:20210817.1 #latest
+      image: ffmgmtacr.azurecr.io/build-agent-tools:20210816.2 #latest
       credentials:
         username: ${{ secrets.CLIENTID }}
         password: ${{ secrets.CLIENTSECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.txt
 tenant/terraform.tfstate.backup
 tenant/test.tfplan
+*.tfstate

--- a/tenant/dummy
+++ b/tenant/dummy
@@ -1,0 +1,1 @@
+dummy text file, changed to trigger build

--- a/tenant/dummy
+++ b/tenant/dummy
@@ -1,1 +1,0 @@
-dummy text file, changed to trigger build


### PR DESCRIPTION
* Prefix CI script calls with `bash`
* Use `envsmgmt` as root Management Group
* Hard code root name and root id to `ForeFront-Test` and `forefrtest` respectively
* Exclude `.tfstate` from source control